### PR TITLE
Release 1.2.95

### DIFF
--- a/gluu-server/opt/gluu/jetty/oxauth/custom/scripts/person_authentication/SignInCanada.py
+++ b/gluu-server/opt/gluu/jetty/oxauth/custom/scripts/person_authentication/SignInCanada.py
@@ -705,6 +705,8 @@ class PersonAuthentication(PersonAuthenticationType):
         if step == self.STEP_1FA:
             if requestParameters.containsKey("failure"): # User cancelled
                 return self.gotoStep(self.STEP_CHOOSER)
+            elif requestParameters.containsKey("chooser"): # User double-clicked
+                return self.gotoStep(self.STEP_1FA)
             else:
                 if providerInfo["GCCF"] and "collect" in rpConfig:
                     user = userService.getUser(userId, "persistentId")

--- a/gluu-server/opt/gluu/jetty/oxauth/custom/scripts/person_authentication/SignInCanada.py
+++ b/gluu-server/opt/gluu/jetty/oxauth/custom/scripts/person_authentication/SignInCanada.py
@@ -326,7 +326,7 @@ class PersonAuthentication(PersonAuthenticationType):
 
         elif requestParameters.containsKey("failure"):
             # This means that passport returned an error
-            if step == self.STEP_1FA: # User Cancelled during login
+            if step <= self.STEP_1FA: # User Cancelled during login
                 if len(self.providers) == 1: # One provider. Redirect back to the RP
                     facesService.redirectToExternalURL(self.getClientUri(session))
                 else: # Clear the previous choice to re-display the chooser


### PR DESCRIPTION
This is a minor bug fix release that:
1. Corrects an issue where selecting "Cancel" on the GCKey login page would cause a Sign In Error for relying parties that only use GCKey.
2. Corrects an issue where double-clicking a selection on the chooser page would cause a Sign In Error.