### PR TITLE
Remove AOMT GCKey signup CTA block from chooser pages (EN/FR)

### DIFF
--- a/gluu-server/opt/gluu/jetty/oxauth/custom/pages/WEB-INF/incl/components/choosers/gccf-en.xhtml
+++ b/gluu-server/opt/gluu/jetty/oxauth/custom/pages/WEB-INF/incl/components/choosers/gccf-en.xhtml
@@ -107,12 +107,6 @@
         </section>
       </div>
     </div>
-    <div class="row text-center">
-      <h2 class="mrgn-tp-md">Don't have a username or password?</h2>
-      <p>
-        <button jsf:id="gckeyregister" jsf:action="#{authenticator.authenticate}" styleClass="btn btn-primary mrgn-tp-lg btn-lg" value="Sign up with GCKey" type="submit">Sign up with GCKey</button>
-      </p>
-    </div>
   </form>
 
 </ui:composition>

--- a/gluu-server/opt/gluu/jetty/oxauth/custom/pages/WEB-INF/incl/components/choosers/gccf-fr.xhtml
+++ b/gluu-server/opt/gluu/jetty/oxauth/custom/pages/WEB-INF/incl/components/choosers/gccf-fr.xhtml
@@ -116,11 +116,5 @@
         </section>
       </div>
     </div>
-    <div class="row text-center">
-      <h2 class="mrgn-tp-md">Vous n’avez pas de nom d’utilisateur ou de mot de passe ?</h2>
-      <p>
-        <button jsf:id="gckeyregister" jsf:action="#{authenticator.authenticate}" styleClass="btn btn-primary mrgn-tp-lg btn-lg" value="gckeyregister" type="submit">Inscrivez-vous pour obtenir une cléGC</button>
-      </p>
-    </div>
   </form>
 </ui:composition>


### PR DESCRIPTION
This change removes only the bottom self-registration call-to-action block from the AOMT chooser page in both English and French templates.

Files changed:
- /Users/kevanadlard/Github CDS/Acceptance-Platform/gluu-server/opt/gluu/jetty/oxauth/custom/pages/WEB-INF/incl/components/choosers/gccf-en.xhtml
- /Users/kevanadlard/Github CDS/Acceptance-Platform/gluu-server/opt/gluu/jetty/oxauth/custom/pages/WEB-INF/incl/components/choosers/gccf-fr.xhtml

What was removed:
- Heading text ("Don't have a username or password?" / French equivalent)
- GCKey registration button (jsf:id="gckeyregister")

What was NOT changed:
- Existing GCKey sign-in flow
- Existing Sign-In Partner flow
- Authentication scripts, Java code, configs, services, certs, or pipelines

Risk profile:
- Template-only markup deletion in existing JSF page
- No logic/path/endpoint changes
- No data model or infrastructure changes